### PR TITLE
script-api: use more descriptive command names

### DIFF
--- a/.inst-list
+++ b/.inst-list
@@ -1,6 +1,6 @@
 --owner=root --group=root
-./usr/bin/cont-entry
-./usr/bin/cont-help
+./usr/bin/container-entrypoint
+./usr/bin/container-usage
 ./usr/share/cont-docs/
 ./usr/share/cont-docs/README
 ./usr/share/cont-volume/

--- a/bin/Makefile.inc
+++ b/bin/Makefile.inc
@@ -1,7 +1,7 @@
-entry		= %D%/cont-entry
+entry		= %D%/container-entrypoint
 entry_in	= %D%/entry.in
 
-help		= %D%/cont-help
+help		= %D%/container-usage
 help_in	= %D%/help.in
 
 GENERATED_FILES += \

--- a/bin/help.in
+++ b/bin/help.in
@@ -9,11 +9,11 @@ cat <<EOF
 General container help
 ======================
 
-Run 'docker run THIS_IMAGE cont-help' to get this help.
+Run 'docker run THIS_IMAGE container-usage' to get this help.
 
-Run 'docker run -ti CONTAINERID bash' to obtain interactive shell.
+Run 'docker run -ti THIS_IMAGE bash' to obtain interactive shell.
 
-Run 'docker exec CONTAINERID cont-entry' to access already running container.
+Run 'docker exec CONTAINERID bash' to access already running container.
 
 You may try '-e CONT_DEBUG=VAL' with VAL up to 3 to get more verbose debugging
 info.

--- a/configure.ac
+++ b/configure.ac
@@ -38,9 +38,8 @@ _AX_TEXT_TPL_ARG_VAR([contvolumehookdir], ['${datadir}/cont-volume'],
                      [place for per-package volume-mounted hook directories])
 
 
-# Files named '*.txt' in this directory will be printed to standard output
-# when 'cont-help' is run.  Any file put in this directory should be named like
-# COMPONENT_NAME.txt.
+# Files named '*.txt' in this directory will be printed to standard output when
+# 'container-usage' is run.
 _AX_TEXT_TPL_ARG_VAR([contdocdir], ['${datadir}/cont-docs'],
                      [container documentation directory])
 

--- a/share/cont-docs/README
+++ b/share/cont-docs/README
@@ -1,1 +1,1 @@
-Filese '*.txt' are automatically read and added to 'cont-help' output.
+Files '*.txt' are automatically read and added to 'container-usage' output.


### PR DESCRIPTION
Use container-usage and container-entrypoint instead of cont-help
and cont-entry.
- .inst-list: Distribute renamed scripts.
- bin/Makefile.inc: Build renamed scripts.
- bin/help.in: Suggest using renamed scripts.  Also, suggest using
  of 'bash' instead of 'container-entrypoint' to obtain interactive
  shell via 'docker exec'.  Its tough to simulate the behavior of
  ENTRYPOINT statement for 'docker exec' but it is thought that
  suggesting the use of 'container-entrypoing' in exec is
  not conceptual and we would be widely hated.  Fix the output to be
  valid markdown text, rhscl2dockerfile project uses it like that.
- configure.ac: Fix comment to comment new command name.
- share/cont-docs/README: Typofix and again mentioning right
  "usage" script name.
